### PR TITLE
Add achievements page: completion overview and per-game missing achievements

### DIFF
--- a/packages/web/app/achievements/[id]/page.tsx
+++ b/packages/web/app/achievements/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, Trophy, TriangleAlert } from "lucide-react";
+import { ArrowLeft, TriangleAlert,Trophy } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 

--- a/packages/web/app/achievements/[id]/page.tsx
+++ b/packages/web/app/achievements/[id]/page.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { ArrowLeft, Trophy, TriangleAlert } from "lucide-react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+import { AchievementBrowser } from "@/components/achievements/achievement-browser";
+import { Header } from "@/components/header";
+import { LoadingIndicator } from "@/components/shared/loading-indicator";
+import { SafeImage } from "@/components/shared/safe-image";
+import { Shimmer } from "@/components/shared/shimmer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { useServerQuery } from "@/lib/hooks/use-server-query";
+import { useSession } from "@/lib/providers/session";
+import { getGameAchievementsForUser } from "@/server/queries/achievements";
+
+export default function GameAchievementsPage() {
+    const { id } = useParams<{ id: string }>();
+    const { user, isLoading: sessionLoading } = useSession();
+
+    const { data: result, isLoading: queryLoading, isRevalidating, mutate } = useServerQuery(
+        user && id ? ["game-achievements-page", id, user.id] : null,
+        () => getGameAchievementsForUser({ gameId: id }),
+    );
+
+    const isLoading = sessionLoading || queryLoading || result === undefined;
+    const data = result?.success ? result.data : null;
+    const loadFailed = result !== undefined && !result?.success;
+    const notFound = data !== null && (data.game === null || data.total === 0);
+
+    const percent = data && data.total > 0
+        ? Math.round((data.unlockedCount / data.total) * 100)
+        : 0;
+
+    return (
+        <>
+            <Header />
+
+            <div className="container-fluid mx-auto px-4 py-6 max-w-4xl">
+                <Button variant="ghost" size="sm" className="mb-4 -ml-2" asChild>
+                    <Link href="/achievements">
+                        <ArrowLeft className="size-4" />
+                        All achievements
+                    </Link>
+                </Button>
+
+                {isLoading ? (
+                    <div className="space-y-4">
+                        <Shimmer className="h-24 rounded-xl" />
+                        {Array.from({ length: 6 }).map((_, i) => (
+                            <Shimmer key={i} className="h-16 rounded-lg" />
+                        ))}
+                    </div>
+                ) : loadFailed ? (
+                    <Card className="bg-card border-destructive/50">
+                        <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+                            <TriangleAlert className="h-10 w-10 text-destructive" />
+                            <p className="text-sm text-muted-foreground">Failed to load achievements.</p>
+                            <Button variant="outline" size="sm" onClick={() => void mutate()}>
+                                Try Again
+                            </Button>
+                        </CardContent>
+                    </Card>
+                ) : notFound || !data?.game ? (
+                    <Card className="bg-card border-border">
+                        <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+                            <Trophy className="h-10 w-10 text-muted-foreground" />
+                            <p className="text-sm font-medium">No achievements found</p>
+                            <p className="max-w-md text-sm text-muted-foreground">
+                                This game doesn&apos;t exist or has no achievement data yet.
+                            </p>
+                        </CardContent>
+                    </Card>
+                ) : (
+                    <div className="space-y-6">
+                        <div className="rounded-xl border bg-card p-4">
+                            <div className="flex items-center gap-4">
+                                <div className="relative h-14 w-32 shrink-0 overflow-hidden rounded-md bg-muted">
+                                    <SafeImage
+                                        srcs={[data.game.capsuleImageUrl, data.game.headerImageUrl]}
+                                        alt={data.game.name}
+                                        width={184}
+                                        height={69}
+                                        className="h-full w-full object-cover"
+                                        fallbackLabel={data.game.name}
+                                        fallbackClassName="rounded-md"
+                                    />
+                                </div>
+
+                                <div className="min-w-0 flex-1 space-y-2">
+                                    <div className="flex items-center justify-between gap-3">
+                                        <h1 className="truncate text-lg font-semibold tracking-tight">
+                                            {data.game.name}
+                                        </h1>
+                                        <span className="shrink-0 text-sm text-muted-foreground">
+                                            {data.unlockedCount} / {data.total}
+                                            <span className="ml-2 font-semibold text-foreground">{percent}%</span>
+                                        </span>
+                                    </div>
+
+                                    <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                                        <div
+                                            className="h-full rounded-full bg-primary transition-all duration-500"
+                                            style={{ width: `${percent}%` }}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <AchievementBrowser achievements={data.achievements} />
+                    </div>
+                )}
+            </div>
+
+            <LoadingIndicator show={isRevalidating} />
+        </>
+    );
+}

--- a/packages/web/app/achievements/layout.tsx
+++ b/packages/web/app/achievements/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+    title: "Achievements",
+    description: "Track achievement completion across your Steam library — progress, perfect games, and missing achievements.",
+};
+
+export default function AchievementsLayout({ children }: { children: ReactNode }) {
+    return children;
+}

--- a/packages/web/app/achievements/page.tsx
+++ b/packages/web/app/achievements/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CircleGauge, ListChecks, Medal, Search, Trophy, TriangleAlert } from "lucide-react";
+import { CircleGauge, ListChecks, Medal, Search, TriangleAlert,Trophy } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { GameCompletionList } from "@/components/achievements/game-completion-list";

--- a/packages/web/app/achievements/page.tsx
+++ b/packages/web/app/achievements/page.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { CircleGauge, ListChecks, Medal, Search, Trophy, TriangleAlert } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { GameCompletionList } from "@/components/achievements/game-completion-list";
+import { Header } from "@/components/header";
+import { LoadingIndicator } from "@/components/shared/loading-indicator";
+import { Shimmer } from "@/components/shared/shimmer";
+import { StatCard } from "@/components/shared/stat-card";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useServerQuery } from "@/lib/hooks/use-server-query";
+import { useSession } from "@/lib/providers/session";
+import { getAchievementOverview } from "@/server/queries/achievements";
+
+type SortOption = "completion_desc" | "completion_asc" | "name_asc" | "total_desc" | "recent";
+type FilterOption = "all" | "in_progress" | "perfect" | "not_started";
+
+export default function AchievementsPage() {
+    const { user, isLoading: sessionLoading } = useSession();
+    const [search, setSearch] = useState("");
+    const [sort, setSort] = useState<SortOption>("completion_desc");
+    const [filter, setFilter] = useState<FilterOption>("all");
+
+    const { data: overviewResult, isLoading: overviewLoading, isRevalidating, mutate } = useServerQuery(
+        user ? ["achievement-overview", user.id] : null, () => getAchievementOverview(),
+    );
+
+    const isLoading = sessionLoading || overviewLoading || overviewResult === undefined;
+    const overview = overviewResult?.success ? overviewResult.data : null;
+    const loadFailed = overviewResult !== undefined && !overviewResult?.success;
+
+    const visibleGames = useMemo(() => {
+        if (!overview) return [];
+
+        const query = search.trim().toLowerCase();
+        const filtered = overview.games.filter((g) => {
+            if (query && !g.name.toLowerCase().includes(query)) return false;
+            if (filter === "in_progress") return g.unlocked > 0 && g.unlocked < g.total;
+            if (filter === "perfect") return g.total > 0 && g.unlocked >= g.total;
+            if (filter === "not_started") return g.unlocked === 0;
+            return true;
+        });
+
+        return [...filtered].sort((a, b) => {
+            switch (sort) {
+                case "completion_asc":
+                    return a.percent - b.percent || a.name.localeCompare(b.name);
+                case "name_asc":
+                    return a.name.localeCompare(b.name);
+                case "total_desc":
+                    return b.total - a.total || a.name.localeCompare(b.name);
+                case "recent":
+                    return (b.lastUnlockAt ?? "").localeCompare(a.lastUnlockAt ?? "")
+                        || a.name.localeCompare(b.name);
+                case "completion_desc":
+                default:
+                    return b.percent - a.percent || a.name.localeCompare(b.name);
+            }
+        });
+    }, [overview, search, sort, filter]);
+
+    return (
+        <>
+            <Header />
+
+            <div className="container-fluid mx-auto px-4 py-6">
+                <div className="flex items-center justify-between mb-8">
+                    <div className="space-y-1">
+                        <h1 className="text-2xl font-semibold tracking-tight">Achievements</h1>
+                        <p className="text-sm text-muted-foreground">
+                            Completion progress and missing achievements across your library
+                        </p>
+                    </div>
+                </div>
+
+                {isLoading ? (
+                    <div className="space-y-4">
+                        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                            {Array.from({ length: 4 }).map((_, i) => (
+                                <Shimmer key={i} className="h-16 rounded-xl" />
+                            ))}
+                        </div>
+                        <div className="space-y-2">
+                            {Array.from({ length: 6 }).map((_, i) => (
+                                <Shimmer key={i} className="h-20 rounded-xl" />
+                            ))}
+                        </div>
+                    </div>
+                ) : loadFailed ? (
+                    <Card className="bg-card border-destructive/50">
+                        <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+                            <TriangleAlert className="h-10 w-10 text-destructive" />
+                            <p className="text-sm text-muted-foreground">Failed to load achievement data.</p>
+                            <Button variant="outline" size="sm" onClick={() => void mutate()}>
+                                Try Again
+                            </Button>
+                        </CardContent>
+                    </Card>
+                ) : !overview || overview.games.length === 0 ? (
+                    <Card className="bg-card border-border">
+                        <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+                            <Trophy className="h-10 w-10 text-muted-foreground" />
+                            <p className="text-sm font-medium">No achievement data yet</p>
+                            <p className="max-w-md text-sm text-muted-foreground">
+                                Achievements are imported automatically after your library syncs.
+                                Check back once a sync has completed.
+                            </p>
+                        </CardContent>
+                    </Card>
+                ) : (
+                    <>
+                        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4 mb-4">
+                            <StatCard
+                                icon={<Trophy className="size-4" />}
+                                label="Unlocked"
+                                value={`${overview.stats.totalUnlocked.toLocaleString()} / ${overview.stats.totalAchievements.toLocaleString()}`}
+                            />
+                            <StatCard
+                                icon={<CircleGauge className="size-4" />}
+                                label="Average completion"
+                                value={`${overview.stats.averageCompletion}%`}
+                            />
+                            <StatCard
+                                icon={<Medal className="size-4" />}
+                                label="Perfect games"
+                                value={overview.stats.perfectGames.toLocaleString()}
+                            />
+                            <StatCard
+                                icon={<ListChecks className="size-4" />}
+                                label="In progress"
+                                value={overview.stats.gamesInProgress.toLocaleString()}
+                            />
+                        </div>
+
+                        <div className="mb-4 flex flex-col gap-2 md:flex-row md:items-center">
+                            <div className="relative flex-1 group">
+                                <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground group-focus-within:text-primary transition-colors" />
+                                <Input
+                                    placeholder="Search games..."
+                                    value={search}
+                                    onChange={(e) => setSearch(e.target.value)}
+                                    className="pl-8 bg-card/50 border-border focus-visible:border-primary"
+                                />
+                            </div>
+
+                            <Select value={sort} onValueChange={(v) => setSort(v as SortOption)}>
+                                <SelectTrigger className="w-full md:w-56">
+                                    <SelectValue placeholder="Sort by..." />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="completion_desc">Completion (High to Low)</SelectItem>
+                                    <SelectItem value="completion_asc">Completion (Low to High)</SelectItem>
+                                    <SelectItem value="name_asc">Name (A-Z)</SelectItem>
+                                    <SelectItem value="total_desc">Most achievements</SelectItem>
+                                    <SelectItem value="recent">Recently unlocked</SelectItem>
+                                </SelectContent>
+                            </Select>
+
+                            <Select value={filter} onValueChange={(v) => setFilter(v as FilterOption)}>
+                                <SelectTrigger className="w-full md:w-44">
+                                    <SelectValue placeholder="Filter..." />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="all">All games</SelectItem>
+                                    <SelectItem value="in_progress">In progress</SelectItem>
+                                    <SelectItem value="perfect">Perfect</SelectItem>
+                                    <SelectItem value="not_started">Not started</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        {visibleGames.length === 0 ? (
+                            <p className="py-10 text-center text-sm text-muted-foreground">
+                                No games match the current search or filter.
+                            </p>
+                        ) : (
+                            <GameCompletionList games={visibleGames} />
+                        )}
+                    </>
+                )}
+            </div>
+
+            <LoadingIndicator show={isRevalidating} />
+        </>
+    );
+}

--- a/packages/web/components/achievements/achievement-browser.tsx
+++ b/packages/web/components/achievements/achievement-browser.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import { Lock, Search } from "lucide-react";
+import Image from "next/image";
+import { useMemo, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+import type { GameAchievementEntry } from "@/server/queries/achievements";
+
+dayjs.extend(relativeTime);
+
+function AchievementRow({ achievement }: { achievement: GameAchievementEntry }) {
+    const unlocked = achievement.achievedAt !== null;
+    const masked = achievement.hidden && !unlocked;
+
+    return (
+        <div
+            className={cn(
+                "flex items-center gap-3 rounded-lg border p-3",
+                unlocked ? "bg-card" : "bg-muted/30 opacity-80",
+            )}
+        >
+            <div className="relative size-12 shrink-0 overflow-hidden rounded bg-muted">
+                {(unlocked ? achievement.icon : achievement.icongray) ? (
+                    <Image
+                        src={unlocked ? achievement.icon : achievement.icongray}
+                        alt={masked ? "Hidden achievement" : achievement.displayName}
+                        fill
+                        className={cn("object-cover", !unlocked && "grayscale")}
+                    />
+                ) : (
+                    <div className="flex size-full items-center justify-center">
+                        <Lock className="size-4 text-muted-foreground" />
+                    </div>
+                )}
+            </div>
+
+            <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium truncate">
+                    {masked ? "Hidden achievement" : achievement.displayName}
+                </p>
+                <p className="text-xs text-muted-foreground line-clamp-2">
+                    {masked
+                        ? "Unlock this achievement to reveal its details."
+                        : achievement.description || " "}
+                </p>
+            </div>
+
+            {unlocked && achievement.achievedAt && (
+                <span
+                    className="shrink-0 text-[11px] text-muted-foreground"
+                    title={new Date(achievement.achievedAt).toLocaleString()}
+                >
+                    {dayjs(achievement.achievedAt).fromNow()}
+                </span>
+            )}
+        </div>
+    );
+}
+
+function RowList({ achievements, emptyText }: { achievements: GameAchievementEntry[]; emptyText: string }) {
+    if (achievements.length === 0) {
+        return <p className="py-10 text-center text-sm text-muted-foreground">{emptyText}</p>;
+    }
+
+    return (
+        <div className="space-y-1.5">
+            {achievements.map((a) => (
+                <AchievementRow key={a.id} achievement={a} />
+            ))}
+        </div>
+    );
+}
+
+/**
+ * Page-scale achievement browser: Missing / Unlocked / All tabs with text
+ * search. Missing achievements sort alphabetically (hidden ones last, since
+ * their names are masked); unlocked ones sort by unlock date, newest first.
+ */
+export function AchievementBrowser({ achievements }: { achievements: GameAchievementEntry[] }) {
+    const [search, setSearch] = useState("");
+
+    const { missing, unlocked, all } = useMemo(() => {
+        const query = search.trim().toLowerCase();
+
+        // Masked hidden achievements expose no text, so they only appear
+        // when no search query is active.
+        const matches = (a: GameAchievementEntry) => {
+            if (!query) return true;
+            if (a.hidden && a.achievedAt === null) return false;
+            return a.displayName.toLowerCase().includes(query)
+                || a.description.toLowerCase().includes(query);
+        };
+
+        const visible = achievements.filter(matches);
+
+        const missingList = visible
+            .filter((a) => a.achievedAt === null)
+            .sort((a, b) => {
+                if (a.hidden !== b.hidden) return a.hidden ? 1 : -1;
+                return a.displayName.localeCompare(b.displayName);
+            });
+
+        const unlockedList = visible
+            .filter((a) => a.achievedAt !== null)
+            .sort((a, b) => (b.achievedAt ?? "").localeCompare(a.achievedAt ?? ""));
+
+        return {
+            missing: missingList,
+            unlocked: unlockedList,
+            all: [...unlockedList, ...missingList],
+        };
+    }, [achievements, search]);
+
+    const hasMissing = achievements.some((a) => a.achievedAt === null);
+
+    return (
+        <Tabs defaultValue={hasMissing ? "missing" : "unlocked"} className="space-y-4">
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <TabsList className="w-auto self-start">
+                    <TabsTrigger value="missing">Missing ({missing.length})</TabsTrigger>
+                    <TabsTrigger value="unlocked">Unlocked ({unlocked.length})</TabsTrigger>
+                    <TabsTrigger value="all">All ({all.length})</TabsTrigger>
+                </TabsList>
+
+                <div className="relative group md:w-72">
+                    <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground group-focus-within:text-primary transition-colors" />
+                    <Input
+                        placeholder="Search achievements..."
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        className="pl-8 bg-card/50 border-border focus-visible:border-primary"
+                    />
+                </div>
+            </div>
+
+            <TabsContent value="missing" className="focus-visible:outline-none">
+                <RowList
+                    achievements={missing}
+                    emptyText={search ? "No missing achievements match your search." : "Nothing missing — this game is 100% complete!"}
+                />
+            </TabsContent>
+            <TabsContent value="unlocked" className="focus-visible:outline-none">
+                <RowList
+                    achievements={unlocked}
+                    emptyText={search ? "No unlocked achievements match your search." : "No achievements unlocked yet."}
+                />
+            </TabsContent>
+            <TabsContent value="all" className="focus-visible:outline-none">
+                <RowList achievements={all} emptyText="No achievements match your search." />
+            </TabsContent>
+        </Tabs>
+    );
+}

--- a/packages/web/components/achievements/game-completion-list.tsx
+++ b/packages/web/components/achievements/game-completion-list.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import { Trophy } from "lucide-react";
+import Link from "next/link";
+
+import { SafeImage } from "@/components/shared/safe-image";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { AchievementGameProgress } from "@/server/queries/achievements";
+
+dayjs.extend(relativeTime);
+
+/**
+ * Vertical list of per-game achievement completion rows. Each row links to
+ * the game's achievement detail page and shows artwork, unlocked/total
+ * counts, the last unlock date, and a completion bar.
+ */
+export function GameCompletionList({ games }: { games: AchievementGameProgress[] }) {
+    return (
+        <div className="space-y-2">
+            {games.map((game) => {
+                const perfect = game.total > 0 && game.unlocked >= game.total;
+
+                return (
+                    <Link
+                        key={game.id}
+                        href={`/achievements/${game.id}`}
+                        className="block rounded-xl border bg-card p-3 transition-all duration-200 hover:border-primary/40 hover:shadow-md hover:shadow-primary/5"
+                    >
+                        <div className="flex items-center gap-4">
+                            <div className="relative h-11 w-24 shrink-0 overflow-hidden rounded-md bg-muted">
+                                <SafeImage
+                                    srcs={[game.capsuleImageUrl, game.headerImageUrl]}
+                                    alt={game.name}
+                                    width={184}
+                                    height={69}
+                                    className="h-full w-full object-cover"
+                                    fallbackLabel={game.name}
+                                    fallbackClassName="rounded-md"
+                                />
+                            </div>
+
+                            <div className="min-w-0 flex-1 space-y-1.5">
+                                <div className="flex items-center justify-between gap-3">
+                                    <p className="flex min-w-0 items-center gap-2 text-sm font-medium">
+                                        <span className="truncate">{game.name}</span>
+                                        {perfect && (
+                                            <Badge className="shrink-0 border-primary/40 bg-primary/15 text-[10px] text-primary">
+                                                <Trophy className="mr-1 size-3" />
+                                                100%
+                                            </Badge>
+                                        )}
+                                    </p>
+                                    <span className="shrink-0 text-xs text-muted-foreground">
+                                        {game.unlocked} / {game.total}
+                                        <span className="ml-2 font-medium text-foreground">{game.percent}%</span>
+                                    </span>
+                                </div>
+
+                                <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                                    <div
+                                        className={cn(
+                                            "h-full rounded-full transition-all",
+                                            perfect ? "bg-primary" : "bg-primary/70",
+                                        )}
+                                        style={{ width: `${game.percent}%` }}
+                                    />
+                                </div>
+
+                                <p className="text-[11px] text-muted-foreground">
+                                    {game.lastUnlockAt
+                                        ? `Last unlock ${dayjs(game.lastUnlockAt).fromNow()}`
+                                        : "No achievements unlocked yet"}
+                                </p>
+                            </div>
+                        </div>
+                    </Link>
+                );
+            })}
+        </div>
+    );
+}

--- a/packages/web/components/game/game-detail-dialog.tsx
+++ b/packages/web/components/game/game-detail-dialog.tsx
@@ -525,7 +525,15 @@ export function GameDetailDialog({game, open, onOpenChange}: GameDetailDialogPro
                             value="achievements"
                             className="focus-visible:outline-none"
                         >
-                            <ScrollArea className="h-120 px-6 pb-2 mt-4">
+                            <div className="flex justify-end px-6 mt-3">
+                                <Button variant="ghost" size="sm" asChild>
+                                    <Link href={`/achievements/${gameId}`}>
+                                        <Trophy className="size-4"/>
+                                        View all
+                                    </Link>
+                                </Button>
+                            </div>
+                            <ScrollArea className="h-110 px-6 pb-2 mt-1">
                                 <AchievementList gameId={gameId}/>
                             </ScrollArea>
                         </TabsContent>

--- a/packages/web/components/header.tsx
+++ b/packages/web/components/header.tsx
@@ -92,6 +92,7 @@ export function Header() {
                             <nav className="hidden md:flex items-center space-x-6">
                                 <NavLink href="/library" isActive={pathname === "/library"}>Library</NavLink>
                                 <NavLink href="/explore" isActive={pathname === "/explore"}>Explore</NavLink>
+                                <NavLink href="/achievements" isActive={pathname.startsWith("/achievements")}>Achievements</NavLink>
                                 <NavLink href="/collections" isActive={pathname.startsWith("/collections")}>Collections</NavLink>
                                 <NavLink href="/vaults" isActive={pathname.startsWith("/vaults")}>Key Vaults</NavLink>
                             </nav>

--- a/packages/web/components/library/library-stats.tsx
+++ b/packages/web/components/library/library-stats.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Clock, Flame, Gamepad2, Trophy } from "lucide-react";
-import type { ReactNode } from "react";
 
+import { StatCard } from "@/components/shared/stat-card";
 import { formatMinutesToHoursMinutes } from "@/lib/utils";
 
 type LibraryStatsGame = {
@@ -10,20 +10,6 @@ type LibraryStatsGame = {
     playtime?: number;
     playtime2Weeks?: number;
 };
-
-function StatCard({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
-    return (
-        <div className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3 min-w-0">
-            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                {icon}
-            </div>
-            <div className="min-w-0">
-                <p className="text-xs text-muted-foreground">{label}</p>
-                <p className="text-sm font-semibold truncate">{value}</p>
-            </div>
-        </div>
-    );
-}
 
 /**
  * Small library summary computed client-side from the already-loaded game

--- a/packages/web/components/mobile-menu.tsx
+++ b/packages/web/components/mobile-menu.tsx
@@ -12,6 +12,7 @@ import { browserLog } from "@/lib/browser-logger";
 const NAV_ITEMS = [
     { href: "/library", label: "Library" },
     { href: "/explore", label: "Explore" },
+    { href: "/achievements", label: "Achievements" },
     { href: "/collections", label: "Collections" },
     { href: "/vaults", label: "Key Vaults" },
     { href: "/settings", label: "Settings" },

--- a/packages/web/components/shared/stat-card.tsx
+++ b/packages/web/components/shared/stat-card.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+/**
+ * Small summary tile: an icon chip next to a label and value. Used in grid
+ * rows on the library and achievements pages.
+ */
+export function StatCard({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+    return (
+        <div className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3 min-w-0">
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                {icon}
+            </div>
+            <div className="min-w-0">
+                <p className="text-xs text-muted-foreground">{label}</p>
+                <p className="text-sm font-semibold truncate">{value}</p>
+            </div>
+        </div>
+    );
+}

--- a/packages/web/server/queries/achievements.ts
+++ b/packages/web/server/queries/achievements.ts
@@ -17,7 +17,18 @@ export type GameAchievementEntry = {
     achievedAt: string | null;
 };
 
+export type AchievementGameMeta = {
+    id: string;
+    name: string;
+    appId: number | null;
+    headerImageUrl: string | null;
+    capsuleImageUrl: string | null;
+    libraryCapsuleUrl: string | null;
+};
+
 export type GameAchievementsForUser = {
+    /** Basic display metadata for the game, or `null` when the game doesn't exist. */
+    game: AchievementGameMeta | null;
     total: number;
     unlockedCount: number;
     achievements: GameAchievementEntry[];
@@ -36,10 +47,23 @@ export const getGameAchievementsForUser = queryClientWithAuth
 
         log.debug("Fetching game achievements for user", { gameId, userId });
 
-        const userGame = await prisma.userGame.findUnique({
-            where:  { userId_gameId: { userId, gameId } },
-            select: { id: true },
-        });
+        const [game, userGame] = await Promise.all([
+            prisma.game.findUnique({
+                where:  { id: gameId },
+                select: {
+                    id: true,
+                    name: true,
+                    appId: true,
+                    headerImageUrl: true,
+                    capsuleImageUrl: true,
+                    libraryCapsuleUrl: true,
+                },
+            }),
+            prisma.userGame.findUnique({
+                where:  { userId_gameId: { userId, gameId } },
+                select: { id: true },
+            }),
+        ]);
 
         const achievements = await prisma.achievement.findMany({
             where: { gameId },
@@ -75,10 +99,116 @@ export const getGameAchievementsForUser = queryClientWithAuth
         });
 
         return {
+            game,
             total: entries.length,
             unlockedCount: entries.filter((e) => e.achievedAt !== null).length,
             achievements: entries,
         };
     }, {
         namespace: "server.queries.achievements:getGameAchievementsForUser",
+    }));
+
+export type AchievementGameProgress = AchievementGameMeta & {
+    total: number;
+    unlocked: number;
+    /** Completion percentage, 0-100, rounded. */
+    percent: number;
+    /** ISO timestamp of the most recent unlock for this game, or `null`. */
+    lastUnlockAt: string | null;
+};
+
+export type AchievementOverview = {
+    stats: {
+        totalUnlocked: number;
+        totalAchievements: number;
+        /** Mean of per-game completion percentages, 0-100, rounded. */
+        averageCompletion: number;
+        perfectGames: number;
+        gamesInProgress: number;
+        gamesNotStarted: number;
+    };
+    /** One entry per owned game that has achievements, completion-desc. */
+    games: AchievementGameProgress[];
+};
+
+/**
+ * Aggregates the current user's achievement progress across their library:
+ * per-game unlocked/total counts with the latest unlock date, plus summary
+ * stats (totals, average completion, perfect games). Only owned games that
+ * actually have achievements are included.
+ */
+export const getAchievementOverview = queryClientWithAuth
+    .query<AchievementOverview>(withLogging(async ({ ctx }, { log }) => {
+        const userId = ctx.user.id;
+
+        log.debug("Fetching achievement overview", { userId });
+
+        const [userGames, latestUnlocks] = await Promise.all([
+            prisma.userGame.findMany({
+                where: { userId, game: { achievements: { some: {} } } },
+                select: {
+                    id: true,
+                    _count: { select: { userGameAchievements: true } },
+                    game: {
+                        select: {
+                            id: true,
+                            name: true,
+                            appId: true,
+                            headerImageUrl: true,
+                            capsuleImageUrl: true,
+                            libraryCapsuleUrl: true,
+                            _count: { select: { achievements: true } },
+                        },
+                    },
+                },
+            }),
+            prisma.userGameAchievement.groupBy({
+                by: ["userGameId"],
+                _max: { achievedAt: true },
+                where: { userGame: { userId } },
+            }),
+        ]);
+
+        const lastUnlockByUserGameId = new Map(
+            latestUnlocks.map((u) => [u.userGameId, u._max.achievedAt]),
+        );
+
+        const games: AchievementGameProgress[] = userGames.map((ug) => {
+            const total = ug.game._count.achievements;
+            const unlocked = Math.min(ug._count.userGameAchievements, total);
+
+            return {
+                id: ug.game.id,
+                name: ug.game.name,
+                appId: ug.game.appId,
+                headerImageUrl: ug.game.headerImageUrl,
+                capsuleImageUrl: ug.game.capsuleImageUrl,
+                libraryCapsuleUrl: ug.game.libraryCapsuleUrl,
+                total,
+                unlocked,
+                percent: total > 0 ? Math.round((unlocked / total) * 100) : 0,
+                lastUnlockAt: lastUnlockByUserGameId.get(ug.id)?.toISOString() ?? null,
+            };
+        });
+
+        games.sort((a, b) => b.percent - a.percent || a.name.localeCompare(b.name));
+
+        const totalAchievements = games.reduce((sum, g) => sum + g.total, 0);
+        const totalUnlocked = games.reduce((sum, g) => sum + g.unlocked, 0);
+
+        return {
+            stats: {
+                totalUnlocked,
+                totalAchievements,
+                averageCompletion: games.length > 0
+                    ? Math.round(games.reduce((sum, g) => sum + g.percent, 0) / games.length)
+                    : 0,
+                perfectGames: games.filter((g) => g.total > 0 && g.unlocked >= g.total).length,
+                gamesInProgress: games.filter((g) => g.unlocked > 0 && g.unlocked < g.total).length,
+                gamesNotStarted: games.filter((g) => g.unlocked === 0).length,
+            },
+            games,
+        };
+    }, {
+        namespace: "server.queries.achievements:getAchievementOverview",
     }));


### PR DESCRIPTION
## Summary

Builds on the achievements import pipeline from #118 with a dedicated place to track progress: a new `/achievements` page showing completion across the whole library, and `/achievements/[id]` for digging into a single game — with the missing achievements front and center.

## Overview page (`/achievements`)

- Summary stat cards: total unlocked (`X / Y`), average completion, perfect games, games in progress — reusing the shared `StatCard` (extracted from the library stats so both pages use one implementation).
- Search, sort (completion, name, most achievements, recently unlocked), and filter (all / in progress / perfect / not started) toolbar, all client-side per app convention.
- Per-game completion rows: artwork (`SafeImage` with capsule → header fallback), unlocked/total with percentage, progress bar, last unlock date, and a `100%` badge for perfected games. Each row links to the detail page.
- Loading shimmer, error-with-retry, and empty states consistent with the collections/vaults pages.

## Detail page (`/achievements/[id]`)

- Game header card with artwork, name, and an overall completion bar.
- Tabbed achievement browser: **Missing** (default when anything is missing, alphabetical with masked hidden achievements last), **Unlocked** (newest first), and **All**, plus text search. Hidden locked achievements stay masked and are excluded from text search so they can't be revealed by probing.
- Handles unknown game ids / games without achievement data with an inline empty card.

## Data

- New `getAchievementOverview` server query: one `userGame.findMany` with relation counts plus a `userGameAchievement.groupBy` for last-unlock dates — no N+1, no schema changes.
- `getGameAchievementsForUser` now additionally returns basic game display metadata (additive; the game detail dialog usage is unchanged).

## Navigation

- "Achievements" added to the desktop and mobile nav.
- The game detail dialog's Achievements tab links to the game's full page via "View all".

No migrations, no worker changes. `lint:web`, `tsc` (web + worker) pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Hw9n6AuCyE39AS8Jj2u2)_